### PR TITLE
#5 generic 응답 모델 생성

### DIFF
--- a/base/utils/constants.py
+++ b/base/utils/constants.py
@@ -3,5 +3,6 @@ from enum import Enum, unique
 
 @unique
 class HttpStatus(Enum):
+    OK = 'OK'
     ROUTINE_OK = 'ROUTINE_OK'
     ROUTINE_CREATE_OK = 'ROUTINE_CREATE_OK'

--- a/base/utils/message.py
+++ b/base/utils/message.py
@@ -1,17 +1,18 @@
 from typing import Generic, TypeVar, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from pydantic.generics import GenericModel
 from base.utils.constants import HttpStatus
 
-DataT = TypeVar('DataT')
+T = TypeVar('T')
+E = TypeVar('E')
 
 
 class Message(BaseModel):
-    status: HttpStatus
-    msg: str
+    status: HttpStatus = HttpStatus.OK
+    msg: str = 'success'
 
 
-class Response(GenericModel, Generic[DataT]):
-    message: Message
-    data: Optional[DataT]
+class Response(GenericModel, Generic[E, T]):
+    message: Optional[E]
+    data: Optional[T]

--- a/retrospect/models/retrospect.py
+++ b/retrospect/models/retrospect.py
@@ -15,19 +15,6 @@ class Retrospect(Base):
     # OneToOne
     image = relationship('Snapshot', back_populates='retrospect', uselist=False)
 
-    # ManyToOne
-    routine = relationship('Routine', back_populates='retrospects')
-
-    routine_id = Column(Integer, ForeignKey('routines.routine_id'))
-
-    content = Column(String)
-
-    result = Column(Enum(Result))
-
-    is_report = Column(Boolean, default=False)
-
-    date = Column(DateTime(timezone=True))
-
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     def add_image(self, url):

--- a/retrospect/repository/retrospectRepository.py
+++ b/retrospect/repository/retrospectRepository.py
@@ -1,20 +1,6 @@
 from fastapi import UploadFile
 from sqlalchemy.orm import Session
 
-from base.utils.time import convert_str2date
-from retrospect.models.retrospect import Retrospect
-from routine.constants.result import Result
 
-
-def create_retrospect(db: Session, routine_id: str , content: str, date: str, image: UploadFile):
-    date = convert_str2date(date)
-    db_retrospect = Retrospect(routine_id=routine_id,
-                               content=content,
-                               date=date,
-                               result=Result.NOT, is_report=False)
-    # TODO: 이미지 url은 추후에 변경
-    db_retrospect.add_image(image.filename)
-    db.add(db_retrospect)
-    db.commit()
-    db.refresh(db_retrospect)
-    return db_retrospect
+def create_retrospect(db: Session, routine_id: str , image: UploadFile):
+    pass

--- a/retrospect/retrospectRouters.py
+++ b/retrospect/retrospectRouters.py
@@ -2,16 +2,12 @@ from fastapi import APIRouter, Depends, UploadFile, File, Form
 from sqlalchemy.orm import Session
 
 from base.database.database import get_db
-from retrospect.repository.retrospectRepository import create_retrospect
 
 router = APIRouter(prefix='/api/v1/retrospect', tags=['retrospects'])
 
 
 @router.post('/create')
 def create_retrospect_router(routine_id: str = Form(...),
-                             content: str = Form(...),
-                             date: str = Form(...),
                              image: UploadFile = File(...),
                              db: Session = Depends(get_db)):
-    save_retrospect = create_retrospect(db, routine_id, content, date,  image)
-    return save_retrospect
+    pass

--- a/retrospect/schemas.py
+++ b/retrospect/schemas.py
@@ -1,19 +1,12 @@
 from pydantic import BaseModel
 
-from routine.constants.result import Result
-
 
 class RetrospectCoreBase(BaseModel):
     content: str
 
 
 class RetrospectCreateResponse(RetrospectCoreBase):
-    from routine.schemas import RoutineCommonResponse
-    retrospect_id: int
-    date: str
-    image: str
-    result: Result
-    routine: RoutineCommonResponse
+    pass
 
 
 class Retrospect(BaseModel):

--- a/routine/routineRouters.py
+++ b/routine/routineRouters.py
@@ -2,8 +2,10 @@ from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from base.database.database import get_db
+from base.utils.constants import HttpStatus
+from base.utils.message import Response, Message
 from routine.repository.routineRepository import create_routine, get_routine
-from routine.schemas import RoutineCreateRequest
+from routine.schemas import RoutineCreateRequest, RoutineCreateResponse
 
 router = APIRouter(prefix='/api/v1/routine', tags=['routines'])
 
@@ -14,7 +16,11 @@ def get_routine_router(routine_id: int, db: Session = Depends(get_db)):
     return routine
 
 
-@router.post('/create')
+@router.post('/create', response_model=Response[Message, RoutineCreateResponse])
 def create_routine_router(routine: RoutineCreateRequest, db: Session = Depends(get_db)):
     save_routine = create_routine(db, routine)
-    return save_routine
+    response = Response[Message, RoutineCreateResponse](
+        message=Message(status=HttpStatus.ROUTINE_OK, msg='루틴 생성에 성공하셨습니다.'),
+        data=RoutineCreateResponse(routine_id=save_routine.routine_id, success=True)
+                        )
+    return response

--- a/routine/schemas.py
+++ b/routine/schemas.py
@@ -36,19 +36,17 @@ class RoutineCreateRequest(RoutineBase):
 
 
 class RoutineCommonResponse(RoutineBase):
-    routine_id: int
-    # result: Result
-
-
-class RoutineCreateResponse(RoutineCommonResponse):
     pass
 
 
+class RoutineCreateResponse(BaseModel):
+    routine_id: int
+    success: bool
+
+
 class Routine(RoutineBase):
-    from retrospect.schemas import Retrospect
     routine_id: int
     account_id: int
-    retrospects: List[Retrospect] = []
     is_delete: bool
     created_at: datetime
 

--- a/test/routine/test_routineRouters.py
+++ b/test/routine/test_routineRouters.py
@@ -13,10 +13,16 @@ def test_루틴_생성_테스트():
         'category': 0,
         'goal': 'world',
         'start_time': '10:30:00',
-        'days': [1, 2, 3]
+        'days': ['MON', 'WED', 'FRI']
     }
     response = client.request('post', '/api/v1/routine/create', json=request)
     assert_that(response.status_code).is_not_equal_to('200')
+    result = response.json()
+    assert_that(result).is_not_none()
+    data = result['data']
+    assert_that(data['success']).is_true()
+    assert_that(result['message']).is_equal_to({'status': 'ROUTINE_OK', 'msg': '루틴 생성에 성공하셨습니다.'})
+
 
 def test_루틴_생성_성공했을_때():
     # given


### PR DESCRIPTION
제네릭 응답 모델 작성
```python
T = TypeVar('T')
E = TypeVar('E')


class Message(BaseModel):
    status: HttpStatus = HttpStatus.OK
    msg: str = 'success'


class Response(GenericModel, Generic[E, T]):
    message: Optional[E]
    data: Optional[T]
````

쓰는 방법

```python
@router.post('/create', response_model=Response[Message, RoutineCreateResponse])
def create_routine_router(routine: RoutineCreateRequest, db: Session = Depends(get_db)):
    save_routine = create_routine(db, routine)
    response = Response[Message, RoutineCreateResponse](
        message=Message(status=HttpStatus.ROUTINE_OK, msg='루틴 생성에 성공하셨습니다.'),
        data=RoutineCreateResponse(routine_id=save_routine.routine_id, success=True)
                        )
    return response
```

여기서 `response_model` 을 설정하면 해당 응답형태를 제외한 다른 응답 형태가 있을 때 런타임 에러가 일어난다.
현재 작성은 그냥 다 때려 넣었지만 나중에 편의 메서드를 통해 깔끔하게 작성할 예정

---

회고 모델은 다시 리모델링을 할 생각이라 우선 많은 부분을 지웠음
테스트케이스를 실제로 구현하면서 구현할 예정

