### PR TITLE
주어진 요구에 맞는 값을 주지 않았을 때의 에러를 글로벌로 처리

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,31 @@
-from fastapi import FastAPI
-from routine import routineRouters
-from retrospect import retrospectRouters
-from base.database.connection import CONNECTION
+from fastapi import FastAPI, Request, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse
 
+from base.database.connection import CONNECTION
+from retrospect import retrospectRouters
+from routine import routineRouters
 connection = CONNECTION
 app = FastAPI()
 
 app.include_router(routineRouters.router)
 app.include_router(retrospectRouters.router)
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    return JSONResponse(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        content=jsonable_encoder(
+            {
+                "method": request.scope['method'],
+                "type": request.scope['type'],
+                "path": request.scope['path'],
+                "path_params": request.scope['path_params'],
+                "server": request.scope['server'],
+                "detail": exc.errors(),
+                "body": exc.body
+            }
+        )
+    )


### PR DESCRIPTION
```json
{
    "method": "POST",
    "path": "/api/v1/routine/create",
    "path_params": {},
    "server": [
        "127.0.0.1",
        8000
    ],
    "type": "http",
    "detail": [
        {
            "loc": [
                "body",
                "account_id"
            ],
            "msg": "field required",
            "type": "value_error.missing"
        }
    ],
    "body": {
        "title": "hello",
        "category": 0,
        "goal": "world",
        "start_time": "10:30:00",
        "days": [
            "MON",
            "WED",
            "FRI"
        ]
    }
}
```
응답 형태는 다음과 같이 하기로 했다. 
주어진 조건에 맞지 않는 status는 422로 했다. ( 공식문서와 동일하게 적용)
생각해봤는데 결국 에러코드는 백엔드 개발자들이 볼려고 하는 거라 원인을 적어두는 것이 더 중요하다고 생각해서 위와 같이 적용해봤다.
