### PR TITLE
유저 관련 정보 body에서 header로 이동 && 데코레이터 이름 변경

### DIFF
--- a/routine/repository/routine_repository.py
+++ b/routine/repository/routine_repository.py
@@ -9,7 +9,7 @@ from routine.models.routineResult import RoutineResult
 from routine.schemas import RoutineCreateRequest, RoutineResultUpdateRequest
 
 
-def get_routine_list(db: Session, account_id: int, today: str):
+def get_routine_list(db: Session, account_id: str, today: str):
     fields = ['id', 'title', 'goal', 'start_time']
 
     today = convert_str2datetime(today)

--- a/routine/repository/routine_repository.py
+++ b/routine/repository/routine_repository.py
@@ -37,14 +37,14 @@ def get_routine_list(db: Session, account_id: int, today: str):
     return response
 
 
-def create_routine(db: Session, routine: RoutineCreateRequest):
+def create_routine(db: Session, routine: RoutineCreateRequest, account: str):
     days = routine.dict().pop('days')
     start_time = routine.start_time
     start_time = convert_str2time(start_time)
 
     db_routine = Routine(
         title=routine.title, category=routine.category,
-        goal=routine.goal, start_time=start_time, account_id=routine.account_id, is_alarm=routine.is_alarm
+        goal=routine.goal, start_time=start_time, account_id=account, is_alarm=routine.is_alarm
     )
 
     db_routine.init_days(days)
@@ -77,8 +77,8 @@ def get_routine_detail(db: Session, routine_id: int):
     ).options(subqueryload('days').load_only('day'), load_only(*fields)).first()
 
 
-def patch_routine_detail(db: Session, request: RoutineCreateRequest, routine_id: int):
-    routine: Routine = db.query(Routine).filter(Routine.id == routine_id).first()
+def patch_routine_detail(db: Session, request: RoutineCreateRequest, routine_id: int, account: str):
+    routine: Routine = db.query(Routine).filter(and_(Routine.id == routine_id, Routine.account_id == account)).first()
     routine.update_routine(request)
     request_days = set(request.days)
     routine.patch_days(db=db, request_days=request_days)

--- a/routine/routine_routers.py
+++ b/routine/routine_routers.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Header
 from sqlalchemy.orm import Session
 
 from base.database.database import get_db
@@ -24,8 +24,9 @@ def get_routine_list_router(account_id: int, today: Optional[str], db: Session =
 
 
 @router.post('', response_model=Response[Message, SimpleSuccessResponse])
-def create_routine_router(routine: RoutineCreateRequest, db: Session = Depends(get_db)):
-    success = create_routine(db, routine)
+def create_routine_router(routine: RoutineCreateRequest, db: Session = Depends(get_db), account: Optional[str] = Header(None)):
+    print(account)
+    success = create_routine(db, routine, account)
     response = Response[Message, SimpleSuccessResponse](
         message=Message(status=HttpStatus.ROUTINE_CREATE_OK, msg=ROUTINE_CREATE_MESSAGE),
         data=SimpleSuccessResponse(success=success))
@@ -53,8 +54,8 @@ def get_routine_detail_router(routine_id: int, db: Session = Depends(get_db)):
 
 
 @router.patch('/{routine_id}', response_model=Response[Message, SimpleSuccessResponse])
-def patch_routine_detail_router(routine_id: int, request: RoutineCreateRequest, db: Session = Depends(get_db)):
-    success = patch_routine_detail(db=db, routine_id=routine_id, request=request)
+def patch_routine_detail_router(routine_id: int, request: RoutineCreateRequest, db: Session = Depends(get_db), account: Optional[str] = Header(None)):
+    success = patch_routine_detail(db=db, routine_id=routine_id, request=request, account=account)
     response = Response[Message, SimpleSuccessResponse](
         message=Message(status=HttpStatus.ROUTINE_PATCH_OK, msg=ROUTINE_UPDATE_MESSAGE),
         data=SimpleSuccessResponse(success=success)

--- a/routine/routine_routers.py
+++ b/routine/routine_routers.py
@@ -13,9 +13,9 @@ from routine.schemas import RoutineCreateRequest, SimpleSuccessResponse, Routine
 router = APIRouter(prefix='/api/v1/routines', tags=['routines'])
 
 
-@router.get('/account/{account_id}', response_model=Response[Message, Optional[List[RoutineElementResponse]]])
-def get_routine_list_router(account_id: int, today: Optional[str], db: Session = Depends(get_db)):
-    routines = get_routine_list(db, account_id, today)
+@router.get('/account', response_model=Response[Message, Optional[List[RoutineElementResponse]]])
+def get_routine_list_router(today: Optional[str], db: Session = Depends(get_db), account: Optional[str] = Header(None)):
+    routines = get_routine_list(db, account, today)
     response = Response(
         message=Message(status=HttpStatus.ROUTINE_LIST_OK, msg=ROUTINE_GET_MESSAGE),
         data=RoutineElementResponse.to_list_response(routines=routines)

--- a/routine/schemas.py
+++ b/routine/schemas.py
@@ -1,5 +1,4 @@
 import re
-from datetime import datetime
 from typing import List, Optional
 
 from pydantic import BaseModel, validator, root_validator
@@ -11,17 +10,9 @@ from routine.constants.routine_message import \
 from routine.constants.week import Week
 
 
-class SimpleSuccessResponse(BaseModel):
-    success: bool
-
-
 class RoutineCoreBase(BaseModel):
     title: str
     category: Category
-
-
-class RecommendedRoutineResponse(RoutineCoreBase):
-    description: str
 
 
 class RoutineBase(RoutineCoreBase):
@@ -43,7 +34,6 @@ class RoutineBase(RoutineCoreBase):
 
 
 class RoutineCreateRequest(RoutineBase):
-    account_id: int
     is_alarm: Optional[bool] = False
 
     @root_validator
@@ -60,6 +50,11 @@ class RoutineCreateRequest(RoutineBase):
         if valid is None:
             raise ValueError(ROUTINE_FIELD_START_TIME_ERROR_MESSAGE)
         return request
+
+
+class RoutineCreateResponse(BaseModel):
+    routine_id: int
+    success: bool
 
 
 class RoutineElementResponse(BaseModel):
@@ -79,25 +74,6 @@ class RoutineElementResponse(BaseModel):
             ) for routine, result in routines
         ]
         return data
-
-
-class RoutineCommonResponse(RoutineBase):
-    pass
-
-
-class RoutineCreateResponse(BaseModel):
-    routine_id: int
-    success: bool
-
-
-class Routine(RoutineBase):
-    routine_id: int
-    account_id: int
-    is_delete: bool
-    created_at: datetime
-
-    class Config:
-        orm_mode = True
 
 
 class RoutineResultUpdateRequest(BaseModel):
@@ -134,3 +110,7 @@ class RoutineDetailResponse(BaseModel):
             goal=result.goal, is_alarm=result.is_alarm, days=[RoutineDaysResponse(day=days.day, routine_id=days.routine_id) for days in result.days]
         )
         return res
+
+
+class SimpleSuccessResponse(BaseModel):
+    success: bool

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,7 +37,7 @@ def client() -> Generator:
         yield c
 
 
-def test_idempotent(func):
+def maintain_idempotent(func):
     def inner(db: Session, client: TestClient):
         try:
             ret = func(db, client)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -37,10 +37,9 @@ def client() -> Generator:
         yield c
 
 
-def complex_transaction(func):
+def test_idempotent(func):
     def inner(db: Session, client: TestClient):
         try:
-            print('--transaction--')
             ret = func(db, client)
         finally:
             for model in models:

--- a/test/routine/test_routine_routers.py
+++ b/test/routine/test_routine_routers.py
@@ -16,12 +16,12 @@ from routine.models.routineDay import RoutineDay
 from routine.models.routineResult import RoutineResult
 from routine.repository.routine_repository import patch_routine_detail
 from routine.schemas import RoutineCreateRequest
-from test.conftest import test_idempotent
+from test.conftest import maintain_idempotent
 
 routines_router_url = '/api/v1/routines'
 
 
-@test_idempotent
+@maintain_idempotent
 def test_루틴_생성_성공했을_때(db: Session, client: TestClient):
     # given
     data = {
@@ -47,7 +47,7 @@ def test_루틴_생성_성공했을_때(db: Session, client: TestClient):
     assert_that(body['success']).is_true()
 
 
-@test_idempotent
+@maintain_idempotent
 def test_루틴_생성이_해당_수행하는_요일과_맞을_때(db: Session, client: TestClient):
     # given
     data = {
@@ -81,7 +81,7 @@ def test_루틴_생성이_해당_수행하는_요일과_맞을_때(db: Session, 
     assert_that(routine_results[0].result).is_equal_to('NOT')
 
 
-@test_idempotent
+@maintain_idempotent
 def test_루틴_생성이_해당_수행하는_요일과_맞지_않을때(db: Session, client: TestClient):
     now_weekday = datetime.datetime.now().weekday()
     days = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
@@ -140,7 +140,7 @@ def test_루틴_생성_루틴_이름_공백일_때(db: Session, client: TestClie
     assert_that(body).is_equal_to(data)
 
 
-@test_idempotent
+@maintain_idempotent
 def test_루틴_생성_카테고리_선택하지_않을_때(db: Session, client: TestClient):
     # given
     data = {
@@ -172,7 +172,7 @@ def test_루틴_생성_카테고리_선택하지_않을_때(db: Session, client:
     assert_that(body).is_equal_to(data)
 
 
-@test_idempotent
+@maintain_idempotent
 def test_루틴_생성_요일_값_전달받지_못할_때(db: Session, client: TestClient):
     # given
     data = {
@@ -204,7 +204,7 @@ def test_루틴_생성_요일_값_전달받지_못할_때(db: Session, client: T
     assert_that(body).is_equal_to(data)
 
 
-@test_idempotent
+@maintain_idempotent
 def test_루틴_생성_알람보내기값이_null일_때(db: Session, client: TestClient):
     # given
     data = {
@@ -229,7 +229,7 @@ def test_루틴_생성_알람보내기값이_null일_때(db: Session, client: Te
     assert_that(body['success']).is_true()
 
 
-@test_idempotent
+@maintain_idempotent
 def test_루틴_전체조회(db: Session, client: TestClient):
     # given
     data = {
@@ -248,7 +248,8 @@ def test_루틴_전체조회(db: Session, client: TestClient):
     today = get_now()
     # when
     response = client.get(
-        f'{routines_router_url}/account/{account_id}?today={today.strftime("%Y-%m-%d")}',
+        f'{routines_router_url}/account?today={today.strftime("%Y-%m-%d")}',
+        headers={'account': '1'}
     )
     result = response.json()
     message = result['message']
@@ -262,7 +263,7 @@ def test_루틴_전체조회(db: Session, client: TestClient):
     assert_that(body['result']).is_equal_to('NOT')
 
 
-@test_idempotent
+@maintain_idempotent
 def test_루틴_조회_이때_루틴결과값이_여러개이지만_하나만_가져오는지(db: Session, client: TestClient):
     now_weekday = datetime.datetime.now().weekday()
     days = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
@@ -285,7 +286,8 @@ def test_루틴_조회_이때_루틴결과값이_여러개이지만_하나만_�
     tomorrow = today + timedelta(days=1)
     # when
     response = client.get(
-        f'{routines_router_url}/account/{account_id}?today={tomorrow.strftime("%Y-%m-%d")}',
+        f'{routines_router_url}/account?today={tomorrow.strftime("%Y-%m-%d")}',
+        headers={'account': '1'}
     )
     result = response.json()
     body = result['data'][0]
@@ -310,12 +312,12 @@ def test_루틴_조회_이때_루틴결과값이_여러개이지만_하나만_�
     assert_that(body['success']).is_true()
 
     response = client.get(
-        f'{routines_router_url}/account/{account_id}?today={tomorrow.strftime("%Y-%m-%d")}',
+        f'{routines_router_url}/account?today={tomorrow.strftime("%Y-%m-%d")}',
+        headers={'account': '1'}
     )
     result = response.json()
     body = result['data'][0]
     assert_that(body['result']).is_equal_to('DONE')
-    pass
 
 
 def test_루틴_값_수정하는데_요일일_때(db: Session, client: TestClient):
@@ -355,7 +357,7 @@ def test_루틴_값_수정하는데_요일일_때(db: Session, client: TestClien
     assert_that(result).is_equal_to(sorted(patch_data['days']))
 
 
-@test_idempotent
+@maintain_idempotent
 def test_루틴_값_수정하는데_요일이_아닌_다른_것(db: Session, client: TestClient):
     # given
     data = {
@@ -389,7 +391,7 @@ def test_루틴_값_수정하는데_요일이_아닌_다른_것(db: Session, cli
     assert_that(str(result_data['start_time'])).is_equal_to(patch_data.start_time)
 
 
-@test_idempotent
+@maintain_idempotent
 def test_루틴_수행여부_값_저장_오늘이_수행하는_날일_때(db: Session, client: TestClient):
     # given
     now = get_now()
@@ -434,7 +436,7 @@ def test_루틴_수행여부_값_저장_오늘이_수행하는_날일_때(db: Se
     assert_that(routine_result.result).is_equal_to(Result.DONE)
 
 
-@test_idempotent
+@maintain_idempotent
 def test_루틴_결과_체크하는데_Default인_경우(db: Session, client: TestClient):
     # given
     days = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
@@ -479,7 +481,7 @@ def test_루틴_결과_체크하는데_Default인_경우(db: Session, client: Te
     assert_that(len(routine_results)).is_equal_to(1)
 
 
-@test_idempotent
+@maintain_idempotent
 def test_루틴_디테일_조회(db: Session, client: TestClient):
     # given
     data = {

--- a/test/routine/test_routine_routers.py
+++ b/test/routine/test_routine_routers.py
@@ -16,17 +16,16 @@ from routine.models.routineDay import RoutineDay
 from routine.models.routineResult import RoutineResult
 from routine.repository.routine_repository import patch_routine_detail
 from routine.schemas import RoutineCreateRequest
-from test.conftest import complex_transaction
+from test.conftest import test_idempotent
 
 routines_router_url = '/api/v1/routines'
 
 
-@complex_transaction
+@test_idempotent
 def test_루틴_생성_성공했을_때(db: Session, client: TestClient):
     # given
     data = {
         'title': 'wake_up',
-        'account_id': 1,
         'category': 1,
         'goal': 'daily',
         'is_alarm': True,
@@ -36,7 +35,8 @@ def test_루틴_생성_성공했을_때(db: Session, client: TestClient):
     # when
     response = client.post(
         f'{routines_router_url}',
-        json=data
+        json=data,
+        headers={'account': '1'}
     )
     # then
     result = response.json()
@@ -47,12 +47,11 @@ def test_루틴_생성_성공했을_때(db: Session, client: TestClient):
     assert_that(body['success']).is_true()
 
 
-@complex_transaction
+@test_idempotent
 def test_루틴_생성이_해당_수행하는_요일과_맞을_때(db: Session, client: TestClient):
     # given
     data = {
         'title': 'time_test',
-        'account_id': 1,
         'category': 1,
         'goal': 'daily',
         'is_alarm': True,
@@ -62,7 +61,8 @@ def test_루틴_생성이_해당_수행하는_요일과_맞을_때(db: Session, 
     # when
     response = client.post(
         f'{routines_router_url}',
-        json=data
+        json=data,
+        headers={'account': '1'}
     )
     assert_that(response.status_code).is_equal_to(200)
     # select routine
@@ -71,7 +71,7 @@ def test_루틴_생성이_해당_수행하는_요일과_맞을_때(db: Session, 
     assert_that(routine.title).is_equal_to(data['title'])
     assert_that(routine.category.value).is_equal_to(data['category'])
     assert_that(routine.goal).is_equal_to(data['goal'])
-    assert_that(routine.account_id).is_equal_to(data['account_id'])
+    assert_that(routine.account_id).is_equal_to(1)
     assert_that(routine.is_alarm).is_true()
     # select routine_day
     routine_day = db.query(RoutineDay).filter(RoutineDay.routine_id == routine_id).all()
@@ -81,7 +81,7 @@ def test_루틴_생성이_해당_수행하는_요일과_맞을_때(db: Session, 
     assert_that(routine_results[0].result).is_equal_to('NOT')
 
 
-@complex_transaction
+@test_idempotent
 def test_루틴_생성이_해당_수행하는_요일과_맞지_않을때(db: Session, client: TestClient):
     now_weekday = datetime.datetime.now().weekday()
     days = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
@@ -89,7 +89,6 @@ def test_루틴_생성이_해당_수행하는_요일과_맞지_않을때(db: Ses
     # given
     data = {
         'title': 'time_test',
-        'account_id': 1,
         'category': 1,
         'goal': 'daily',
         'is_alarm': True,
@@ -99,7 +98,8 @@ def test_루틴_생성이_해당_수행하는_요일과_맞지_않을때(db: Ses
     # when
     response = client.post(
         f'{routines_router_url}',
-        json=data
+        json=data,
+        headers={'account': '1'}
     )
     assert_that(response.status_code).is_equal_to(200)
     routine = db.query(Routine).order_by(desc(Routine.id)).first()
@@ -112,7 +112,6 @@ def test_루틴_생성_루틴_이름_공백일_때(db: Session, client: TestClie
     # given
     data = {
         'title': '',
-        'account_id': 1,
         'category': 1,
         'goal': 'daily',
         'is_alarm': True,
@@ -122,7 +121,8 @@ def test_루틴_생성_루틴_이름_공백일_때(db: Session, client: TestClie
     # when
     response = client.post(
         f'{routines_router_url}',
-        json=data
+        json=data,
+        headers={'account': '1'}
     )
     # then
     result = response.json()
@@ -140,12 +140,11 @@ def test_루틴_생성_루틴_이름_공백일_때(db: Session, client: TestClie
     assert_that(body).is_equal_to(data)
 
 
-@complex_transaction
+@test_idempotent
 def test_루틴_생성_카테고리_선택하지_않을_때(db: Session, client: TestClient):
     # given
     data = {
         'title': 'wake_up',
-        'account_id': 1,
         'goal': 'daily',
         'is_alarm': True,
         'start_time': '10:00:00',
@@ -154,7 +153,8 @@ def test_루틴_생성_카테고리_선택하지_않을_때(db: Session, client:
     # when
     response = client.post(
         f'{routines_router_url}',
-        json=data
+        json=data,
+        headers={'account': '1'}
     )
     # then
     result = response.json()
@@ -172,12 +172,11 @@ def test_루틴_생성_카테고리_선택하지_않을_때(db: Session, client:
     assert_that(body).is_equal_to(data)
 
 
-@complex_transaction
+@test_idempotent
 def test_루틴_생성_요일_값_전달받지_못할_때(db: Session, client: TestClient):
     # given
     data = {
         'title': 'wake_up',
-        'account_id': 1,
         'category': 1,
         'goal': 'daily',
         'is_alarm': True,
@@ -186,7 +185,8 @@ def test_루틴_생성_요일_값_전달받지_못할_때(db: Session, client: T
     # when
     response = client.post(
         f'{routines_router_url}',
-        json=data
+        json=data,
+        headers={'account': '1'}
     )
     # then
     result = response.json()
@@ -204,12 +204,11 @@ def test_루틴_생성_요일_값_전달받지_못할_때(db: Session, client: T
     assert_that(body).is_equal_to(data)
 
 
-@complex_transaction
+@test_idempotent
 def test_루틴_생성_알람보내기값이_null일_때(db: Session, client: TestClient):
     # given
     data = {
         'title': 'is_alarm',
-        'account_id': 1,
         'category': 1,
         'goal': 'daily',
         'start_time': '10:00:00',
@@ -218,7 +217,8 @@ def test_루틴_생성_알람보내기값이_null일_때(db: Session, client: Te
     # when
     response = client.post(
         f'{routines_router_url}',
-        json=data
+        json=data,
+        headers={'account': '1'}
     )
     # then
     result = response.json()
@@ -229,12 +229,11 @@ def test_루틴_생성_알람보내기값이_null일_때(db: Session, client: Te
     assert_that(body['success']).is_true()
 
 
-@complex_transaction
+@test_idempotent
 def test_루틴_전체조회(db: Session, client: TestClient):
     # given
     data = {
         'title': 'yes',
-        'account_id': 1,
         'category': 1,
         'goal': 'daily',
         'start_time': '10:00:00',
@@ -242,7 +241,8 @@ def test_루틴_전체조회(db: Session, client: TestClient):
     }
     client.post(
         f'{routines_router_url}',
-        json=data
+        json=data,
+        headers={'account': '1'}
     )
     account_id = 1
     today = get_now()
@@ -262,14 +262,13 @@ def test_루틴_전체조회(db: Session, client: TestClient):
     assert_that(body['result']).is_equal_to('NOT')
 
 
-@complex_transaction
+@test_idempotent
 def test_루틴_조회_이때_루틴결과값이_여러개이지만_하나만_가져오는지(db: Session, client: TestClient):
     now_weekday = datetime.datetime.now().weekday()
     days = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
     days.remove(Week.get_weekday(now_weekday))
     data = {
         'title': 'yes',
-        'account_id': 1,
         'category': 1,
         'goal': 'daily',
         'start_time': '10:00:00',
@@ -277,7 +276,8 @@ def test_루틴_조회_이때_루틴결과값이_여러개이지만_하나만_�
     }
     client.post(
         f'{routines_router_url}',
-        json=data
+        json=data,
+        headers={'account': '1'}
     )
     account_id = 1
     from datetime import timedelta
@@ -322,7 +322,6 @@ def test_루틴_값_수정하는데_요일일_때(db: Session, client: TestClien
     # given
     data = {
         'title': 'yes',
-        'account_id': 1,
         'category': 1,
         'goal': 'daily',
         'start_time': '10:00:00',
@@ -330,12 +329,12 @@ def test_루틴_값_수정하는데_요일일_때(db: Session, client: TestClien
     }
     client.post(
         f'{routines_router_url}',
-        json=data
+        json=data,
+        headers={'account': '1'}
     )
-    routine = db.query(Routine).filter(and_(Routine.title == data['title'], Routine.account_id == data['account_id'])).first()
+    routine = db.query(Routine).filter(and_(Routine.title == data['title'], Routine.account_id == 1)).first()
     patch_data = {
         'title': 'bye',
-        'account_id': 1,
         'category': 1,
         'goal': 'say-good-bye',
         'start_time': '11:00:00',
@@ -344,7 +343,8 @@ def test_루틴_값_수정하는데_요일일_때(db: Session, client: TestClien
     # when
     client.patch(
         f'{routines_router_url}/{routine.id}',
-        json=patch_data
+        json=patch_data,
+        headers={'account': '1'}
     )
     # then
     days = db.query(RoutineDay.day).filter(RoutineDay.routine_id == routine.id).all()
@@ -355,12 +355,11 @@ def test_루틴_값_수정하는데_요일일_때(db: Session, client: TestClien
     assert_that(result).is_equal_to(sorted(patch_data['days']))
 
 
-@complex_transaction
+@test_idempotent
 def test_루틴_값_수정하는데_요일이_아닌_다른_것(db: Session, client: TestClient):
     # given
     data = {
         'title': 'yes',
-        'account_id': 1,
         'category': 1,
         'goal': 'daily',
         'start_time': '10:00:00',
@@ -368,16 +367,17 @@ def test_루틴_값_수정하는데_요일이_아닌_다른_것(db: Session, cli
     }
     client.post(
         f'{routines_router_url}',
-        json=data
+        json=data,
+        headers={'account': '1'}
     )
-    routine: Routine = db.query(Routine).filter(and_(Routine.title == data['title'], Routine.account_id == data['account_id'])).first()
+    routine: Routine = db.query(Routine).filter(and_(Routine.title == data['title'], Routine.account_id == 1)).first()
     patch_data = RoutineCreateRequest(
-        title='bye', account_id=1,
+        title='bye',
         category=1, goal='say-good-bye',
         start_time='11:00:00', days=['FRI', 'SAT', 'SUN']
     )
     # when
-    patch_routine_detail(db=db, routine_id=routine.id, request=patch_data)
+    patch_routine_detail(db=db, routine_id=routine.id, request=patch_data, account='1')
     # then
     response = client.get(
         f'{routines_router_url}/{routine.id}'
@@ -389,7 +389,7 @@ def test_루틴_값_수정하는데_요일이_아닌_다른_것(db: Session, cli
     assert_that(str(result_data['start_time'])).is_equal_to(patch_data.start_time)
 
 
-@complex_transaction
+@test_idempotent
 def test_루틴_수행여부_값_저장_오늘이_수행하는_날일_때(db: Session, client: TestClient):
     # given
     now = get_now()
@@ -397,7 +397,6 @@ def test_루틴_수행여부_값_저장_오늘이_수행하는_날일_때(db: Se
     weekday = Week.get_weekday(weekday)
     create = {
         'title': 'wake_up',
-        'account_id': 1,
         'category': 1,
         'goal': 'daily',
         'is_alarm': True,
@@ -407,7 +406,8 @@ def test_루틴_수행여부_값_저장_오늘이_수행하는_날일_때(db: Se
     # when
     client.post(
         f'{routines_router_url}',
-        json=create
+        json=create,
+        headers={'account': '1'}
     )
     routine = db.query(Routine).first()
     now = str(get_now())
@@ -434,7 +434,7 @@ def test_루틴_수행여부_값_저장_오늘이_수행하는_날일_때(db: Se
     assert_that(routine_result.result).is_equal_to(Result.DONE)
 
 
-@complex_transaction
+@test_idempotent
 def test_루틴_결과_체크하는데_Default인_경우(db: Session, client: TestClient):
     # given
     days = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
@@ -444,7 +444,6 @@ def test_루틴_결과_체크하는데_Default인_경우(db: Session, client: Te
     days.remove(weekday)
     create = {
         'title': 'wake_up',
-        'account_id': 1,
         'category': 1,
         'goal': 'daily',
         'is_alarm': True,
@@ -454,7 +453,8 @@ def test_루틴_결과_체크하는데_Default인_경우(db: Session, client: Te
     # when
     client.post(
         f'{routines_router_url}',
-        json=create
+        json=create,
+        headers={'account': '1'}
     )
     routine = db.query(Routine).first()
     now = str(get_now())
@@ -479,12 +479,11 @@ def test_루틴_결과_체크하는데_Default인_경우(db: Session, client: Te
     assert_that(len(routine_results)).is_equal_to(1)
 
 
-@complex_transaction
+@test_idempotent
 def test_루틴_디테일_조회(db: Session, client: TestClient):
     # given
     data = {
         'title': 'time_test',
-        'account_id': 1,
         'category': 1,
         'goal': 'daily',
         'is_alarm': True,
@@ -494,7 +493,8 @@ def test_루틴_디테일_조회(db: Session, client: TestClient):
     # when
     response = client.post(
         f'{routines_router_url}',
-        json=data
+        json=data,
+        headers={'account': '1'}
     )
     assert_that(response.status_code).is_equal_to(200)
     routine: Routine = db.query(Routine).filter(Routine.title == data['title']).first()


### PR DESCRIPTION
- 기존에 body에 유저정보를 넘기는 식으로 진행했는데 헤더가 더 적합하다고 판단.(gateway에서 애시당초 헤더에 있는 유저정보를 파싱하여 넘기는데 body보다는 header가 더 적합하다고 판단)
- 데코레이터 이름 변경 (트랜잭션보다는 멱등성이라는 단어가 더 적합하다고 판단)