### PR TITLE
시간 관련 모킹 문제 우회하여 해결

### DIFF
--- a/base/database/models/model.py
+++ b/base/database/models/model.py
@@ -1,9 +1,14 @@
-from sqlalchemy import Column, DateTime, func, Boolean
+from sqlalchemy import Column, DateTime, Boolean
+
+from base.utils.time import get_now
 
 
 class TimestampMixin(object):
-    modified_at = Column(DateTime, default=func.now())
-    created_at = Column(DateTime, default=func.now())
+    def __init__(self):
+        self.created_at = get_now()
+        self.modified_at = get_now()
+    modified_at = Column(DateTime)
+    created_at = Column(DateTime)
 
 
 class BaseColumnMixin(object):

--- a/routine/models/routine.py
+++ b/routine/models/routine.py
@@ -15,6 +15,7 @@ from routine.schemas import RoutineCreateRequest
 class Routine(BaseColumnMixin, TimestampMixin, Base):
 
     def __init__(self, account_id, title, goal, category, start_time, is_alarm=False):
+        super().__init__()
         self.account_id = account_id
         self.title = title
         self.goal = goal

--- a/routine/models/routineDay.py
+++ b/routine/models/routineDay.py
@@ -9,6 +9,7 @@ from routine.constants.week import Week
 class RoutineDay(TimestampMixin, Base):
 
     def __init__(self, sequence, day):
+        super().__init__()
         self.day = day
         self.sequence = sequence
 

--- a/routine/models/routineResult.py
+++ b/routine/models/routineResult.py
@@ -8,7 +8,8 @@ from routine.constants.result import Result
 
 class RoutineResult(BaseColumnMixin, TimestampMixin, Base):
 
-    def __init__(self,yymmdd: str, result: Result = Result.NOT, routine_id: int = None):
+    def __init__(self, yymmdd: str, result: Result = Result.NOT, routine_id: int = None):
+        super().__init__()
         self.yymmdd = yymmdd
         self.result = result
         self.routine_id = routine_id


### PR DESCRIPTION
- 기본 sqlalchemy에서 제공하는 시간 default에 대한 함수 mocking에 대한 방안이 안보여서 생성자로 해결
- 방법은 데코레이터 freezegun을 통해 해결