### PR TITLE
리포트 조회 로직 작성

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from base.exception.exception import MinningException, common_exception_response
 from base.utils.constants import ConnectionMode
 from retrospect import retrospect_routers
 from routine import routine_routers, routine_batch_router
-from report import report_batch_router
+from report import report_batch_router, report_router
 
 Connection(ddl_mode=ConnectionMode.NONE)
 app = FastAPI()
@@ -16,6 +16,7 @@ app.include_router(routine_routers.router)
 app.include_router(routine_batch_router.router)
 app.include_router(retrospect_routers.router)
 app.include_router(report_batch_router.router)
+app.include_router(report_router.router)
 
 app.add_event_handler('startup', connect_to_mongo)
 app.add_event_handler('shutdown', close_mongo_connection)

--- a/report/batch/report_batch.py
+++ b/report/batch/report_batch.py
@@ -1,7 +1,7 @@
 from fastapi.encoders import jsonable_encoder
 from motor.motor_asyncio import AsyncIOMotorClient
 from base.utils.collection import to_dict
-from base.utils.time import get_now
+from base.utils.time import get_now, get_start_datetime
 from config.settings import settings
 from report.collections import Collections
 from report.schema import CreateReportSchema, RoutineElement, RoutineResultElement, Report, MonthlyReport
@@ -26,7 +26,7 @@ async def create_monthly_report(mongo_db: AsyncIOMotorClient, account_id: int):
     report = MonthlyReport(
         account_id=account_id, weekly_achievement_rate=weekly_achievement_rate,
         category_routine_count=category_routine_count, category_detail=category_detail,
-        created_at=str(get_now())
+        created_at=get_start_datetime(get_now())
     )
     db_report = jsonable_encoder(report)
     new_report = await mongo_db[settings.DB_NAME][Collections.MONTHLY_REPORT.value].insert_one(db_report)
@@ -125,7 +125,7 @@ async def create_weekly_report(mongo_db: AsyncIOMotorClient, request: CreateRepo
             achievement_rate=Report.calculate_achievement_rate(_done=_done, _try=_try, _none=_none),
             done_count=_done, try_count=_try, not_count=_none,
             routine_results=res,
-            created_at=str(get_now())
+            created_at=get_start_datetime(get_now())
         )
         db_report = jsonable_encoder(report)
         new_report = await mongo_db[settings.DB_NAME][Collections.REPORT.value].insert_one(db_report)

--- a/report/constants/report_message.py
+++ b/report/constants/report_message.py
@@ -1,1 +1,2 @@
 REPORT_GET_OK = '리포트 가져오기 성공 했습니다.'
+REPORT_NOT_FOUND = '아직 생성되지 않았습니다.'

--- a/report/report_router.py
+++ b/report/report_router.py
@@ -7,18 +7,26 @@ from base.database.database import get_mongo_db
 from base.dependencies.header import check_account_header
 from base.utils.constants import HttpStatus
 from base.utils.message import Response, Message
-from base.utils.time import validate_date
 from report.constants.report_message import REPORT_GET_OK
-from report.repository.report_repository import get_report
-from report.schema import Report
+from report.repository.report_repository import get_report, get_monthly_report
+from report.schema import Report, MonthlyReport
 
 router = APIRouter(prefix='/api/v1/reports', tags=['reports'], dependencies=[Depends(check_account_header)])
 
 
-@router.get('', response_model=Response[Message, Report])
+@router.get('/week', response_model=Response[Message, Report])
 async def get_weekly_report_router(date: Optional[str], account: Optional[str] = Header(None), mongo_db: AsyncIOMotorClient = Depends(get_mongo_db)):
-    validate_date(date)
     report = await get_report(mongo_db=mongo_db, date=date, account_id=int(account))
+    response = Response(
+        message=Message(status=HttpStatus.REPORT_DETAIL_OK, msg=REPORT_GET_OK),
+        data=report
+    )
+    return response
+
+
+@router.get('/month', response_model=Response[Message, MonthlyReport])
+async def get_monthly_report_router(date: Optional[str], account: Optional[str] = Header(None), mongo_db: AsyncIOMotorClient = Depends(get_mongo_db)):
+    report = await get_monthly_report(mongo_db=mongo_db, date=date, account_id=int(account))
     response = Response(
         message=Message(status=HttpStatus.REPORT_DETAIL_OK, msg=REPORT_GET_OK),
         data=report

--- a/report/repository/report_repository.py
+++ b/report/repository/report_repository.py
@@ -1,6 +1,43 @@
 from motor.motor_asyncio import AsyncIOMotorClient
 
+from base.exception.exception import MinningException
+from base.utils.time import convert_str2datetime, get_start_datetime, get_end_datetime
+from config.settings import settings
+from report.collections import Collections
+from report.constants.report_message import REPORT_NOT_FOUND
+
 
 async def get_report(mongo_db: AsyncIOMotorClient, date: str, account_id: int):
-    report = await mongo_db.reports.find_one({'created_at': date, 'account_id': account_id})
+    start_today = get_start_datetime(convert_str2datetime(date)).strftime('%Y-%m-%dT%H:%M:%S')
+    end_today = get_end_datetime(convert_str2datetime(date)).strftime('%Y-%m-%dT%H:%M:%S')
+    report = await mongo_db[settings.DB_NAME][Collections.REPORT].find_one(
+        {
+            'created_at': {
+                '$gte': start_today, '$lte': end_today
+            },
+            'account_id': account_id
+        }, {
+            '_id': 0
+        }
+    )
+    if not report:
+        raise MinningException(REPORT_NOT_FOUND)
+    return report
+
+
+async def get_monthly_report(mongo_db: AsyncIOMotorClient, date: str, account_id: int):
+    start_today = get_start_datetime(convert_str2datetime(date)).strftime('%Y-%m-%dT%H:%M:%S')
+    end_today = get_end_datetime(convert_str2datetime(date)).strftime('%Y-%m-%dT%H:%M:%S')
+    report = await mongo_db[settings.DB_NAME][Collections.MONTHLY_REPORT].find_one(
+        {
+            'created_at': {
+                '$gte': start_today, '$lte': end_today
+            },
+            'account_id': account_id
+        }, {
+            '_id': 0
+        }
+    )
+    if not report:
+        raise MinningException(REPORT_NOT_FOUND)
     return report

--- a/report/schema.py
+++ b/report/schema.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Optional, List, Dict
 
 from bson import ObjectId
@@ -52,7 +53,7 @@ class MonthlyReport(BaseModel):
     weekly_achievement_rate: List[float]
     category_routine_count: Dict[str, int]
     category_detail: Dict[str, Dict[str, CategoryRoutineElement]]
-    created_at: str
+    created_at: datetime.datetime
 
     class Config:
         allow_population_by_field_name = True
@@ -63,7 +64,7 @@ class MonthlyReport(BaseModel):
         schema_extra = {
             'example': {
                 'account_id': 1,
-                'weekly_achievement_rate': [80, 42, 100, 90],
+                'weekly_achievement_rate': [0.625, 0.7, 0.8, 0.9],
                 'category_routine_count': {
                     'MIRACLE': 3,
                     'SELF': 2,
@@ -102,7 +103,7 @@ class Report(BaseModel):
     try_count: int
     not_count: int
     routine_results: Optional[List[RoutineElement]]
-    created_at: str
+    created_at: datetime.datetime
 
     @classmethod
     def calculate_achievement_rate(cls, _done, _try, _none):
@@ -117,7 +118,7 @@ class Report(BaseModel):
         schema_extra = {
             'example': {
                 'account_id': 1,
-                'achievement_rate': 70,
+                'achievement_rate': 0.625,
                 'done_count': 6,
                 'try_count': 2,
                 'not_count': 2,

--- a/test/report/test_batch_report.py
+++ b/test/report/test_batch_report.py
@@ -1,0 +1,75 @@
+import json
+import random
+
+from assertpy import assert_that
+from httpx import AsyncClient
+from motor.motor_asyncio import AsyncIOMotorClient
+from test.report.utils import __make_report_data
+
+from routine.constants.category import Category
+from test.conftest import maintain_idempotent_async
+
+routines_router_url = '/api/v1/routines'
+routines_batch_router_url = '/api/v1/batch-routines'
+report_batch_router_url = '/api/v1/batch-reports'
+
+
+@maintain_idempotent_async()
+async def test_주_리포트_생성(anyio_backend, async_client: AsyncClient, mongo_db: AsyncIOMotorClient):
+    # given
+    data = await __make_report_data()
+    response = await async_client.post(
+        f'{report_batch_router_url}/week',
+        content=json.dumps(data)
+    )
+    data = response.json()
+    assert_that(data['done_count']).is_equal_to(5)
+    assert_that(data['not_count']).is_equal_to(3)
+    assert_that(data['try_count']).is_equal_to(0)
+    assert_that(data['achievement_rate']).is_equal_to(0.625)
+    assert_that(len(data['routine_results'])).is_equal_to(8)
+
+
+@maintain_idempotent_async()
+async def test_월_리포트_생성(anyio_backend, async_client: AsyncClient, mongo_db: AsyncIOMotorClient):
+    categories = [Category.DAILY.value, Category.SELF.value, Category.HEALTH.value, Category.MIRACLE.value]
+    categories = random.sample(categories, 3)
+    data = await __make_report_data(date='2022-01-10', categories=categories)
+    await async_client.post(
+        f'{report_batch_router_url}/week',
+        content=json.dumps(data)
+    )
+
+    data = await __make_report_data(date='2022-01-17', categories=categories)
+    await async_client.post(
+        f'{report_batch_router_url}/week',
+        content=json.dumps(data)
+    )
+
+    data = await __make_report_data(date='2022-01-24', categories=categories)
+    await async_client.post(
+        f'{report_batch_router_url}/week',
+        content=json.dumps(data)
+    )
+
+    data = await __make_report_data(date='2022-01-31', categories=categories)
+    await async_client.post(
+        f'{report_batch_router_url}/week',
+        content=json.dumps(data)
+    )
+
+    response = await async_client.post(
+        f'{report_batch_router_url}/month?account-id=1'
+    )
+    data = response.json()
+    category_detail = data['category_detail']
+    total = 0
+    for k, v in category_detail.items():
+        total += len(v.keys())
+    assert_that(total).is_equal_to(8)
+    total = 0
+    category_routine_count = data['category_routine_count']
+    for k, v in category_routine_count.items():
+        total += v
+    assert_that(total).is_equal_to(8)
+    assert_that(data['weekly_achievement_rate'][0]).is_equal_to(0.625)

--- a/test/report/utils.py
+++ b/test/report/utils.py
@@ -1,0 +1,89 @@
+from datetime import timedelta
+
+from base.utils.time import convert_str2datetime
+
+
+async def __make_report_data(date="2022-02-07 00:00:00", categories=('SELF', 'MIRACLE', 'DAILY')):
+    data = {
+        "routines": [
+            {
+                "title": "글5",
+                "category": categories[0],
+                "id": 6,
+                "account_id": 1
+            }, {
+                "title": "글6",
+                "category": categories[0],
+                "id": 7,
+                "account_id": 1
+            }, {
+                "title": "글7",
+                "category": categories[1],
+                "id": 8,
+                "account_id": 1
+            }, {
+                "title": "글8",
+                "category": categories[1],
+                "id": 9,
+                "account_id": 1
+            }, {
+                "title": "글9",
+                "category": categories[2],
+                "id": 10,
+                "account_id": 1
+            }, {
+                "title": "글10",
+                "category": categories[2],
+                "id": 11,
+                "account_id": 1
+            }, {
+                "title": "글11",
+                "category": categories[0],
+                "id": 12,
+                "account_id": 1
+            }, {
+                "title": "글12",
+                "category": categories[0],
+                "id": 13,
+                "account_id": 1
+            }
+
+        ],
+        "routine_results": [
+            {
+                "routine_id": 6,
+                "date": date,
+                "result": "DONE"
+            }, {
+                "routine_id": 7,
+                "date": date,
+                "result": "DONE"
+            }, {
+                "routine_id": 8,
+                "date": date,
+                "result": "NOT"
+            }, {
+                "routine_id": 9,
+                "date": date,
+                "result": "NOT"
+            }, {
+                "routine_id": 10,
+                "date": date,
+                "result": "NOT"
+            }, {
+                "routine_id": 11,
+                "date": str(convert_str2datetime(date) + timedelta(days=2)),
+                "result": "DONE"
+            }, {
+                "routine_id": 12,
+                "date": str(convert_str2datetime(date) + timedelta(days=2)),
+                "result": "DONE"
+            }, {
+                "routine_id": 13,
+                "date": str(convert_str2datetime(date) + timedelta(days=5)),
+                "result": "DONE"
+            }
+        ]
+    }
+
+    return data


### PR DESCRIPTION
```python
 {
            'created_at': {
                '$gte': start_today, '$lte': end_today
            },
            'account_id': account_id
        }, {
            '_id': 0
        }
```
와 같이 한 이유는 다음과 같다.
- 우선 _id를 0으로 안하면 스키마를 통해 아이디가 생성되기 때문에 이를 방지하기 위해 0이라는 값을 넣어놨다.
- 날짜 조회시 $eq로 하면 조회가 안되서 우선 하루의 시작과 끝을 기준으로 조회를 하였다.